### PR TITLE
Fix functions build error by adding rootDir to tsconfig

### DIFF
--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -4,6 +4,7 @@
 		"noImplicitReturns": true,
 		"noUnusedLocals": true,
 		"outDir": "lib",
+		"rootDir": "src",
 		"sourceMap": true,
 		"strict": true,
 		"target": "es2020"


### PR DESCRIPTION
## Summary

- `functions/tsconfig.json` に `"rootDir": "src"` を追加
- TypeScript 5.x では `outDir` 指定時に `rootDir` の明示が必要になったため、`npm --prefix functions run build` が失敗していた

## Test plan

- [x] `npm --prefix functions run build` が正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)